### PR TITLE
Add a link JRuby 9.1.15.0 issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ source ~/.bashrc</code></pre>
 
       <h3>Set up with JRuby</h3>
       <p>Download your preferred version 9.x.y of JRuby Complete jar from <a href="https://www.jruby.org/download">JRuby Downloads</a>, and put it in your favorite directory.</p>
-      <p>Embulk is tested with old JRuby 9.1.15.0 as of now.</p>
+      <p>Embulk is tested with old JRuby 9.1.15.0 as of now.(However, this version has an <a href="articles/2023/07/28/embulk-gem-install-in-v0_9-series-sometime-fails.html">issue</a>. You may need to try newer JRuby.)</p>
 
 
       <p>Then, create <code>~/.embulk/embulk.properties</code> as follows.</p>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ source ~/.bashrc</code></pre>
 
       <h3>Set up with JRuby</h3>
       <p>Download your preferred version 9.x.y of JRuby Complete jar from <a href="https://www.jruby.org/download">JRuby Downloads</a>, and put it in your favorite directory.</p>
-      <p>Embulk is tested with old JRuby 9.1.15.0 as of now.(However, this version has an <a href="articles/2023/07/28/embulk-gem-install-in-v0_9-series-sometime-fails.html">issue</a>. You may need to try newer JRuby.)</p>
+      <p>Embulk is tested with old JRuby 9.1.15.0 as of now. (However, older JRuby has an <a href="articles/2023/07/28/embulk-gem-install-in-v0_9-series-sometime-fails.html">issue in installing Ruby gems</a>. You may need to try newer JRuby.)</p>
 
 
       <p>Then, create <code>~/.embulk/embulk.properties</code> as follows.</p>


### PR DESCRIPTION
[The user](https://twitter.com/raki/status/1688848458273476608?s=20) reported JRuby 9.1.15.0 Issue (That user tried v0.11.0 with JRuby 9.1.15.0. then encountered [this issue](https://www.embulk.org/articles/2023/07/28/embulk-gem-install-in-v0_9-series-sometime-fails.html)

This PR adds caution to avoid the same issue.