### PR TITLE
Publish GitHub Pages using GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+# Ref https://github.com/actions/starter-workflows/blob/main/pages/jekyll-gh-pages.yml
+name: Publish
+on:
+  push:
+    branches: ["main"]
+#
+# This block is necessary for the `actions/deploy-pages` actions.
+# If this part does not exist, raise the following error.
+#   Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable 
+#
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+#
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Jekyll outputs contents to _site by default.
+        # Set destination path explicitly.
+        # Just copied template file.
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Take the following actions before this PR merge.

- [x] Change the GitHub Pages -> Build and deployment  -> source to "GitHub Actions"
- [x] Add the `main` branch to `Deployment branches and tags` in the Environments setting. 