### PR TITLE
Update Quick Start in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,42 +81,35 @@
 
     <section id="quick-start">
       <h2>Quick Start</h2>
-      <p>Embulk runs on Java. Make sure Java Runtime is installed.</p>
-      <p>Embulk v0.9 (past stable) run only on Java 8.</p>
-      <p>Embulk v0.11 officially supports only Java 8, but expected to work somehow with Java 11, and 17. We are going to test v0.11 with Java 11 and 17 so that we can declare an official support for them.</p>
 
-      <h3>Linux &amp; macOS</h3>
-<pre><code>curl --create-dirs -o ~/.embulk/bin/embulk -L "https://dl.embulk.org/embulk-latest.jar"
-chmod +x ~/.embulk/bin/embulk
-echo 'export PATH="$HOME/.embulk/bin:$PATH"' &gt;&gt; ~/.bashrc
-source ~/.bashrc</code></pre>
+      <p>Set up the Java Runtime Environment. Embulk runs on Java. Embulk v0.11 officially supports only Java 8, but expected to work somehow with Java 11, 17, and 21.</p>
+      <p>Download the latest `embulk-X.Y.Z.jar` from: [GitHub Releases](https://github.com/embulk/embulk/releases)</p>
 
-      <h3>Windows</h3>
-      <pre><code>PowerShell -Command "&amp; {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::TLS12; Invoke-WebRequest http://dl.embulk.org/embulk-latest.jar -OutFile embulk.bat}"</code></pre>
+      <p>Try the following commands. <code>embulk example</code> command generates an example CSV file.</p>
+      <pre><code>java -jar embulk-X.Y.Z.jar example ./try1
+java -jar embulk-X.Y.Z.jar guess ./try1/seed.yml -o config.yml
+java -jar embulk-X.Y.Z.jar preview config.yml
+java -jar embulk-X.Y.Z.jar run config.yml</code></pre>
+
+      <h3>Install an Embulk plugin</h3>
+
+      <p>Install an Embulk plugin (ex. S3 Input Plugin) with the following command.</p>
+      <pre><code>java -jar embulk-X.Y.Z.jar install "org.embulk:embulk-input-s3:0.6.0"</code></pre>
 
       <h3>Set up with JRuby</h3>
+
+      <p>If you need to use a RubyGems-style Embulk plugin, you'll have to set up with JRuby.</p>
       <p>Download your preferred version 9.x.y of JRuby Complete jar from <a href="https://www.jruby.org/download">JRuby Downloads</a>, and put it in your favorite directory.</p>
       <p>Embulk is tested with old JRuby 9.1.15.0 as of now. (However, older JRuby has an <a href="articles/2023/07/28/embulk-gem-install-in-v0_9-series-sometime-fails.html">issue in installing Ruby gems</a>. You may need to try newer JRuby.)</p>
-
 
       <p>Then, create <code>~/.embulk/embulk.properties</code> as follows.</p>
       <pre><code>jruby=file:///path/to/jruby-complete-9.x.y.z.jar</code></pre>
 
       <p>Finally, install some Ruby gems.</p>
-
       <pre><code>embulk gem install embulk -v {{ site.embulk_version }} # Must be the same Embulk version
 embulk gem install msgpack
 embulk gem install bundler # if you need Bundler
 embulk gem install liquid  # if you need Liquid</code></pre>
-
-      <h3>Next steps</h3>
-      <p>The <code>embulk example</code> command generates an example CSV file.</p>
-      <p>You can try Embulk quickly by:</p>
-<pre><code>embulk example ./try1
-embulk guess ./try1/seed.yml -o config.yml
-embulk preview config.yml
-embulk run config.yml
-</code></pre>
     </section>
 
     <section id="presentation">


### PR DESCRIPTION
Update the "Quick Start" with `java` command lines, Maven-style plugins, and downloading from GitHub Releases.